### PR TITLE
basic persistence + ephemeral

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,6 @@
 # build options
 build --color=yes
 build --cxxopt='-std=c++17'
-build -c dbg # temporary
 
 # build config
 build:all kvstore:server func:server warble:warble

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ bazel*
 .vscode
 .vagrant
 Vagrantfile
-test.txt

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bazel*
 .vscode
 .vagrant
 Vagrantfile
+test.txt

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 ## Setup
 
 1. Setup a [Vagrant](https://app.vagrantup.com) VM with the [`ubuntu/bionic64`](https://app.vagrantup.com/ubuntu/boxes/bionic64) box.
+
 2. Install [`bazel`](https://bazel.build).
+
 3. Clone this repository:
 
   ```
@@ -33,8 +35,9 @@ bazel test --config=all
 1. Start the key value store:
 
   ```
-  bazel run --config=kvstore
+  ./bazel-bin/kvstore/server [--store <file>]
   ```
+(Note: the store is run without bazel because otherwise the paths for the persistence feature become overly complicated.)
 
 2. Start the FaaS server:
 
@@ -45,15 +48,17 @@ bazel test --config=all
 3. Warble!
 
   ```
-   bazel run --config=warble -- <args>
+   bazel run --config=warble -- [flags]
   ```
-
-  `<args>` can be one of the following:
+  
+You must include one of the following flags, but not both:
 
   `--registeruser <username>` - registers the given username
-
+  
   `--user <username>` - logs in as the given username
 
+If the `--user` flag is specified, you must include one of the following actions:
+  
   `--warble <warble text>` - creates a new warble with the given text
 
   `--reply <reply warble id>` - indicates that the new warble is a reply to the given id

--- a/func/server.h
+++ b/func/server.h
@@ -27,8 +27,9 @@ using grpc::Status, grpc::ServerContext, grpc::WriteOptions,
     kvstore::KeyValueStore;
 
 /*
-  Creates and runs a server that manages hooking, unhooking, and executions of arbitrary functions.
-  Functions are to be defined elsewhere and included in this file (eg, #include "warble/functions.h").
+  Creates and runs a server that manages hooking, unhooking, and executions of
+  arbitrary functions. Functions are to be defined elsewhere and included in
+  this file (eg, #include "warble/functions.h").
 */
 class FuncServer final : public FuncService::Service {
  public:

--- a/kvstore/BUILD
+++ b/kvstore/BUILD
@@ -26,6 +26,7 @@ cc_binary(
   deps = [
     "@com_github_grpc_grpc//:grpc++",
     "@com_github_google_glog//:glog",
+    "@com_github_gflags_gflags//:gflags",
     "//protos:kvstore_grpc_library",
     ":store",
   ],

--- a/kvstore/BUILD
+++ b/kvstore/BUILD
@@ -9,6 +9,7 @@ cc_library(
   includes = ["BAZEL_BUILD"],
   deps = [
     "@com_github_google_glog//:glog",
+    "@com_github_grpc_grpc//:grpc++",
     "//protos:kvstore_grpc_library",
   ],
 )

--- a/kvstore/BUILD
+++ b/kvstore/BUILD
@@ -6,6 +6,11 @@ cc_library(
   name = "store",
   srcs = ["store.cc"],
   hdrs = ["store.h"],
+  includes = ["BAZEL_BUILD"],
+  deps = [
+    "@com_github_google_glog//:glog",
+    "//protos:kvstore_grpc_library",
+  ],
 )
 
 cc_library(

--- a/kvstore/client.cc
+++ b/kvstore/client.cc
@@ -14,7 +14,7 @@ bool KVStoreClient::put(std::string key, std::string value) {
   if (s.ok()) {
     return true;
   } else {
-    std::cout << s.error_code() << "\t" << s.error_message() << std::endl;
+    LOG(ERROR) << s.error_code() << "\t" << s.error_message();
     return false;
   }
 }
@@ -34,7 +34,7 @@ std::optional<std::vector<std::string>> KVStoreClient::get(std::string key) {
   if (s.ok()) {
     return values;
   } else {
-    std::cout << s.error_code() << "\t" << s.error_message() << std::endl;
+    LOG(ERROR) << s.error_code() << "\t" << s.error_message();
     return std::nullopt;
   }
 }
@@ -48,7 +48,7 @@ bool KVStoreClient::remove(std::string key) {
   if (s.ok()) {
     return true;
   } else {
-    std::cout << s.error_code() << "\t" << s.error_message() << std::endl;
+    LOG(ERROR) << s.error_code() << "\t" << s.error_message();
     return false;
   }
 }

--- a/kvstore/client.h
+++ b/kvstore/client.h
@@ -10,7 +10,8 @@
 
 using kvstore::KeyValueStore, grpc::ChannelInterface;
 
-// A Database client that is specific to the gRPC-loaded KVStoreServer (see kvstore/server.h)
+// A Database client that is specific to the gRPC-loaded KVStoreServer (see
+// kvstore/server.h)
 class KVStoreClient : public Database {
  public:
   KVStoreClient(std::shared_ptr<ChannelInterface> channel)

--- a/kvstore/server.cc
+++ b/kvstore/server.cc
@@ -60,14 +60,14 @@ void KVStoreServer::read(const std::string &file) {
   store_.read(file);
 }
 
-DEFINE_string(file, "", "File from/to which to read/write the contents of the store.");
+DEFINE_string(store, "", "File from/to which to read/write the contents of the store.");
 
 // must be global to support access from signalHandler
 KVStoreServer server;
 
 void signalHandler(int i) {
   std::cout << "caught signal\t" << i << std::endl;
-  server.dump(FLAGS_file);
+  server.dump(FLAGS_store);
   exit(i);
 }
 
@@ -79,10 +79,10 @@ int main(int argc, char** argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   
   // link termination/interrupt signals to the handler function
-  if (FLAGS_file != "") {
+  if (FLAGS_store != "") {
     signal(SIGTERM, signalHandler);
     signal(SIGINT, signalHandler);
-    server.read(FLAGS_file);
+    server.read(FLAGS_store);
   }
 
   // Initializes a key value store service and connects it to port 50001.

--- a/kvstore/server.cc
+++ b/kvstore/server.cc
@@ -52,21 +52,17 @@ Status KVStoreServer::remove(ServerContext* context,
   return Status::OK;
 }
 
-void KVStoreServer::dump(const std::string &file) {
-  store_.dump(file);
-}
+void KVStoreServer::dump(const std::string& file) { store_.dump(file); }
 
-void KVStoreServer::read(const std::string &file) {
-  store_.read(file);
-}
+void KVStoreServer::read(const std::string& file) { store_.read(file); }
 
-DEFINE_string(store, "", "File from/to which to read/write the contents of the store.");
+DEFINE_string(store, "",
+              "File from/to which to read/write the contents of the store.");
 
 // must be global to support access from signalHandler
 KVStoreServer server;
 
 void signalHandler(int i) {
-  std::cout << "caught signal\t" << i << std::endl;
   server.dump(FLAGS_store);
   exit(i);
 }
@@ -77,7 +73,7 @@ int main(int argc, char** argv) {
   google::InitGoogleLogging(argv[0]);
   gflags::SetUsageMessage("Please run  with -h flag to see usage");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
-  
+
   // link termination/interrupt signals to the handler function
   if (FLAGS_store != "") {
     signal(SIGTERM, signalHandler);

--- a/kvstore/server.cc
+++ b/kvstore/server.cc
@@ -53,12 +53,10 @@ Status KVStoreServer::remove(ServerContext* context,
 }
 
 void KVStoreServer::dump(const std::string &file) {
-  std::cout << "dumping contents of the store to\t" << file << std::endl;
   store_.dump(file);
 }
 
 void KVStoreServer::read(const std::string &file) {
-  std::cout << "reading contents of the store from\t" << file << std::endl;
   store_.read(file);
 }
 

--- a/kvstore/server.h
+++ b/kvstore/server.h
@@ -17,6 +17,7 @@
 
 #include "protos/kvstore.grpc.pb.h"
 #include "store.h"
+#include "gflags/gflags.h"
 
 using grpc::Status, grpc::ServerContext, grpc::ServerWriter, grpc::WriteOptions,
     kvstore::KeyValueStore, kvstore::PutRequest, kvstore::PutReply,
@@ -33,7 +34,10 @@ class KVStoreServer final : public KeyValueStore::Service {
              ServerWriter<GetReply>*) override;
   // Removes all values associated with a key.
   Status remove(ServerContext*, const RemoveRequest*, RemoveReply*) override;
-
+  // Tells the KVStore server to dump its contents to a file
+  void dump(const std::string&);
+  // Tells the KVStore server to read its contents from a file
+  void read(const std::string&);
  private:
   KVStore store_;
 };

--- a/kvstore/server.h
+++ b/kvstore/server.h
@@ -15,9 +15,9 @@
 #include <iostream>
 #include <unordered_map>
 
+#include "gflags/gflags.h"
 #include "protos/kvstore.grpc.pb.h"
 #include "store.h"
-#include "gflags/gflags.h"
 
 using grpc::Status, grpc::ServerContext, grpc::ServerWriter, grpc::WriteOptions,
     kvstore::KeyValueStore, kvstore::PutRequest, kvstore::PutReply,
@@ -38,6 +38,7 @@ class KVStoreServer final : public KeyValueStore::Service {
   void dump(const std::string&);
   // Tells the KVStore server to read its contents from a file
   void read(const std::string&);
+
  private:
   KVStore store_;
 };

--- a/kvstore/store.cc
+++ b/kvstore/store.cc
@@ -12,6 +12,7 @@
 #include "store.h"
 
 bool KVStore::put(const std::string &key, const std::string &value) {
+  std::unique_lock<std::shared_mutex> lck(mu_);
   if (map_.find(key) == map_.end()) {
     map_[key].push_back(value);
   } else {
@@ -27,6 +28,7 @@ bool KVStore::put(const std::string &key, const std::string &value) {
 }
 
 std::optional<std::vector<std::string>> KVStore::get(const std::string &key) {
+  std::shared_lock<std::shared_mutex> lck(mu_);
   if (map_.find(key) != map_.end()) {
     return map_[key];
   } else {
@@ -35,6 +37,7 @@ std::optional<std::vector<std::string>> KVStore::get(const std::string &key) {
 }
 
 bool KVStore::remove(const std::string &key) {
+  std::unique_lock<std::shared_mutex> lck(mu_);
   if (map_.find(key) == map_.end()) {
     return false;  // could not find key in map
   } else {
@@ -44,6 +47,7 @@ bool KVStore::remove(const std::string &key) {
 }
 
 void KVStore::read(const std::string &file) {
+  std::unique_lock<std::shared_mutex> lck(mu_);
   LOG(INFO) << "reading store contents from\t" << file;
   std::ifstream fs(file);
   if (fs.is_open()) {
@@ -65,6 +69,7 @@ void KVStore::read(const std::string &file) {
 }
 
 void KVStore::dump(const std::string &file) {
+  std::shared_lock<std::shared_mutex> lck(mu_);
   LOG(INFO) << "dumping to\t" << file;
   kvstore::Store store;
   // populate store structure

--- a/kvstore/store.cc
+++ b/kvstore/store.cc
@@ -7,10 +7,6 @@
     `put(key, value)` associates `value` with `key` in the store
     `get(key)` returns stream of values associated with `key`
     `remove(key)` removes all values associated with `key`
-
-  TODO
-    - make thread safe
-    - modify keys to include namespaces (ie, bitstrings)
 */
 
 #include "store.h"

--- a/kvstore/store.cc
+++ b/kvstore/store.cc
@@ -46,3 +46,43 @@ bool KVStore::remove(const std::string &key) {
     return true;
   }
 }
+
+void KVStore::read(const std::string &file) {
+  std::cout << "reading" << std::endl;
+  std::ifstream fs(file);
+  if (fs.is_open()) {
+    std::string key;
+    while (std::getline(fs, key)) {
+      std::cout << key << std::endl;
+      size_t s;
+      fs >> s;
+      std::vector<std::string> vals;
+      std::string val;
+      while (s) {
+        std::getline(fs, val);
+        vals.push_back(val);
+        s--;
+      }
+      map_[key] = vals;
+    }
+  } else {
+    std::cout << "can't open file" << std::endl;
+  }
+}
+
+void KVStore::dump(const std::string &file) {
+  std::cout << "dumping" << std::endl;
+  std::ofstream fs;
+  fs.open(file);
+  std::unordered_map<std::string, std::vector<std::string>>::iterator itr;
+  for (itr = map_.begin(); itr != map_.end(); ++itr) {
+    std::string key = itr->first;
+    std::vector<std::string> vals = itr->second;
+    fs << key << std::endl;
+    fs << vals.size() << std::endl;
+    for (std::string s : vals) {
+      fs << s << std::endl;
+    }
+  }
+  fs.close();
+}

--- a/kvstore/store.h
+++ b/kvstore/store.h
@@ -15,6 +15,9 @@
 #include <vector>
 #include <iostream>
 #include <fstream>
+#include <glog/logging.h>
+
+#include "protos/kvstore.pb.h"
 
 // Backend data structure for storing values in memory, using std::unordered_map.
 class KVStore {

--- a/kvstore/store.h
+++ b/kvstore/store.h
@@ -13,15 +13,20 @@
 #include <optional>
 #include <unordered_map>
 #include <vector>
+#include <iostream>
+#include <fstream>
 
 // Backend data structure for storing values in memory, using std::unordered_map.
 class KVStore {
  public:
   bool put(const std::string&, const std::string&);
-  // Keys that do not have values will return std::nullopt
+  // Keys that do not have values will return std::nullopt from get
   std::optional<std::vector<std::string>> get(const std::string&);
   bool remove(const std::string&);
-
+  // Dumps the contents of the kvstore to the file
+  void dump(const std::string&);
+  // Reads the contents of the file to the kvstore
+  void read(const std::string&);
  private:
   std::unordered_map<std::string, std::vector<std::string>> map_;
 };

--- a/kvstore/store.h
+++ b/kvstore/store.h
@@ -9,19 +9,21 @@
 #ifndef KVSTORE_H
 #define KVSTORE_H
 
+#include <glog/logging.h>
+
 #include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <mutex>
 #include <optional>
+#include <shared_mutex>
 #include <unordered_map>
 #include <vector>
-#include <iostream>
-#include <fstream>
-#include <glog/logging.h>
-#include <mutex>
-#include <shared_mutex>
 
 #include "protos/kvstore.pb.h"
 
-// Backend data structure for storing values in memory, using std::unordered_map.
+// Backend data structure for storing values in memory, using
+// std::unordered_map.
 class KVStore {
  public:
   bool put(const std::string&, const std::string&);
@@ -32,6 +34,7 @@ class KVStore {
   void dump(const std::string&);
   // Reads the contents of the file to the kvstore
   void read(const std::string&);
+
  private:
   std::unordered_map<std::string, std::vector<std::string>> map_;
   std::shared_mutex mu_;

--- a/kvstore/store.h
+++ b/kvstore/store.h
@@ -16,6 +16,8 @@
 #include <iostream>
 #include <fstream>
 #include <glog/logging.h>
+#include <mutex>
+#include <shared_mutex>
 
 #include "protos/kvstore.pb.h"
 
@@ -32,6 +34,7 @@ class KVStore {
   void read(const std::string&);
  private:
   std::unordered_map<std::string, std::vector<std::string>> map_;
+  std::shared_mutex mu_;
 };
 
 #endif  // !KVSTORE_H

--- a/protos/kvstore.proto
+++ b/protos/kvstore.proto
@@ -27,6 +27,16 @@ message RemoveReply {
   // Empty because success/failure is signaled via GRPC status.
 }
 
+// the following structures are used exclusively for serializing to/parsing from database files
+message Pair {
+  bytes key = 1;
+  repeated bytes values = 2;
+}
+
+message Store {
+  repeated Pair pairs = 1;
+}
+
 service KeyValueStore {
   rpc put (PutRequest) returns (PutReply) {}
   rpc get (GetRequest) returns (stream GetReply) {}

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -6,6 +6,7 @@ cc_test(
   copts = ["-Iexternal/gtest/include"],
   deps = [
     "@gtest//:main",
+    "@com_github_google_glog//:glog",
     "//kvstore:store",
   ],
   timeout = "short",
@@ -17,6 +18,7 @@ cc_test(
   copts = ["-Iexternal/gtest/include"],
   deps = [
     "@gtest//:main",
+    "@com_github_google_glog//:glog",
     "//kvstore:store",
     "//warble:functions",
   ],

--- a/tests/funcs.cc
+++ b/tests/funcs.cc
@@ -37,7 +37,7 @@ TEST_F(FuncsTest, RegisterUser) {
   EXPECT_FALSE(RegisterUser(&db, req, &rep));
 }
 
-TEST_F(FuncsTest, Warble) {
+TEST_F(FuncsTest, WarbleNormal) {
   Any req, rep;
   WarbleRequest w_req;
   w_req.set_username("gabroo");
@@ -47,6 +47,39 @@ TEST_F(FuncsTest, Warble) {
   w_req.set_username("not_a_user_that_exists");
   req.PackFrom(w_req);
   EXPECT_FALSE(Follow(&db, req, &rep));
+}
+
+TEST_F(FuncsTest, WarbleValidReply) {
+  Any req, rep;
+  WarbleRequest w_req;
+  w_req.set_username("gabroo");
+  w_req.set_text("parent warble");
+  req.PackFrom(w_req);
+  EXPECT_TRUE(Warble(&db, req, &rep));
+  WarbleReply w_rep;
+  rep.UnpackTo(&w_rep);
+  auto id = w_rep.warble().id();
+  w_req.set_username("gabroo");
+  w_req.set_text("reply warble");
+  w_req.set_parent_id(id);
+  req.PackFrom(w_req);
+  EXPECT_TRUE(Warble(&db, req, &rep));
+}
+
+TEST_F(FuncsTest, WarbleInvalidReply) {
+  Any req, rep;
+  WarbleRequest w_req;
+  w_req.set_username("gabroo");
+  w_req.set_text("parent warble");
+  req.PackFrom(w_req);
+  EXPECT_TRUE(Warble(&db, req, &rep));
+  WarbleReply w_rep;
+  rep.UnpackTo(&w_rep);
+  w_req.set_username("gabroo");
+  w_req.set_text("reply warble");
+  w_req.set_parent_id("not_a_valid_id");
+  req.PackFrom(w_req);
+  EXPECT_FALSE(Warble(&db, req, &rep));
 }
 
 TEST_F(FuncsTest, Follow) {

--- a/tests/funcs.cc
+++ b/tests/funcs.cc
@@ -1,3 +1,5 @@
+#include <glog/logging.h>
+
 #include "gtest/gtest.h"
 #include "kvstore/db.h"
 #include "kvstore/store.h"
@@ -19,7 +21,6 @@ class FuncsTest : public ::testing::Test {
  protected:
   FakeDB db;
   void SetUp() override {
-    db = FakeDB();
     db.put("_users_", "gabroo");
     db.put("_users_", "gabru");
     db.put("_users_", "gabbru");
@@ -109,6 +110,7 @@ TEST_F(FuncsTest, Profile) {
 }
 
 int main(int argc, char** argv) {
+  google::InitGoogleLogging(argv[0]);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/tests/kvstore.cc
+++ b/tests/kvstore.cc
@@ -1,7 +1,7 @@
-#include <vector>
-#include <thread>
-
 #include <glog/logging.h>
+
+#include <thread>
+#include <vector>
 
 #include "gtest/gtest.h"
 #include "kvstore/store.h"
@@ -22,15 +22,13 @@ TEST_F(KVStoreTest, ConcurrencyTests) {
   auto increment = [this]() {
     int cur = std::stoi((*store.get("count"))[0]);
     store.remove("count");
-    store.put("count", std::to_string(cur+1));
+    store.put("count", std::to_string(cur + 1));
   };
   std::vector<std::thread> q;
   for (int i = 0; i < 100; ++i) {
     q.push_back(std::thread(increment));
   }
-  std::for_each(q.begin(), q.end(), [](std::thread &t) {
-    t.join();
-  });
+  std::for_each(q.begin(), q.end(), [](std::thread& t) { t.join(); });
   std::string result = (*store.get("count"))[0];
   EXPECT_EQ(stoi(result), 100);
 }

--- a/tests/kvstore.cc
+++ b/tests/kvstore.cc
@@ -1,22 +1,42 @@
 #include <vector>
+#include <glog/logging.h>
 
 #include "gtest/gtest.h"
 #include "kvstore/store.h"
-
-using std::string;
-using std::vector;
 
 class KVStoreTest : public ::testing::Test {
  protected:
   KVStore store;
   void SetUp() override {
-    store = KVStore();
     store.put("key1", "val11");
     store.put("key1", "val12");
     store.put("key2", "val2");
     store.put("key3", "val3");
   }
 };
+
+TEST_F(KVStoreTest, Dump) {
+  std::FILE* f = std::fopen("test.txt", "r");
+  if (f != nullptr) std::remove("test.txt");
+  store.dump("test.txt");
+  f = std::fopen("test.txt", "r");
+  EXPECT_TRUE(f != nullptr);
+}
+
+TEST_F(KVStoreTest, DumpAndRead) {
+  store.dump("test.txt");
+  KVStore newstore;
+  newstore.read("test.txt");
+  auto exists = newstore.get("key1");
+  std::vector<std::string> vals = *exists;
+  EXPECT_EQ((int)vals.size(), 2);
+  EXPECT_EQ(vals[0], "val11");
+  EXPECT_EQ(vals[1], "val12");
+  exists = newstore.get("key2");
+  vals = *exists;
+  EXPECT_EQ((int)vals.size(), 1);
+  EXPECT_EQ(vals[0], "val2");
+}
 
 TEST_F(KVStoreTest, Put) {
   EXPECT_TRUE(store.put("key3", "val31"));
@@ -52,6 +72,7 @@ TEST_F(KVStoreTest, Remove) {
 }
 
 int main(int argc, char** argv) {
+  google::InitGoogleLogging(argv[0]);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/warble/functions.cc
+++ b/warble/functions.cc
@@ -21,6 +21,7 @@ bool Warble(Database* db, Any req, Any* rep) {
   req.UnpackTo(&request);
   std::string username = request.username(), text = request.text(),
               parent_id = request.parent_id(), key = "_warbles_" + username;
+  // check if user is registered
   auto exists = db->get("_users_");
   if (exists) {
     if (std::find((*exists).begin(), (*exists).end(), username) ==
@@ -29,6 +30,15 @@ bool Warble(Database* db, Any req, Any* rep) {
   } else {
     return false;
   }
+  // check if reply is valid
+  if (!parent_id.empty()) {
+    auto exists = db->get("_warble_"+parent_id);
+    if (!exists) {
+      LOG(INFO) << "Tried to reply to a warble that does not exist.";
+      return false;
+    }
+  }
+  // generate warble id
   std::string warble_id;
   exists = db->get(key);
   if (exists) {

--- a/warble/functions.cc
+++ b/warble/functions.cc
@@ -32,7 +32,7 @@ bool Warble(Database* db, Any req, Any* rep) {
   }
   // check if reply is valid
   if (!parent_id.empty()) {
-    auto exists = db->get("_warble_"+parent_id);
+    auto exists = db->get("_warble_" + parent_id);
     if (!exists) {
       LOG(INFO) << "Tried to reply to a warble that does not exist.";
       return false;

--- a/warble/warble.cc
+++ b/warble/warble.cc
@@ -30,14 +30,16 @@ int main(int argc, char** argv) {
   CLI cli(CreateChannel(address, InsecureChannelCredentials()));
   if (FLAGS_registeruser == "" && FLAGS_user == "") {
     std::cout << "Must specify either --registeruser (to sign up) or --user "
-                 "(to log in).\n";
+                 "(to log in)." << std::endl;
     return 1;
+  } else if (FLAGS_registeruser != "" && FLAGS_user != "") {
+    std::cout << "Cannot both login and register at the same time. Please use one of the flags." << std::endl;
   } else {
     if (FLAGS_registeruser != "") {
       cli.RegisterUser(FLAGS_registeruser);
     } else {
       if (FLAGS_user == "") {
-        std::cout << "Must login with the --user flag.\n";
+        std::cout << "Must login with the --user flag." << std::endl;
         return 2;
       } else {
         if (FLAGS_warble != "" && FLAGS_read == "" && !FLAGS_profile &&
@@ -54,7 +56,7 @@ int main(int argc, char** argv) {
           cli.Follow(FLAGS_user, FLAGS_follow);
         } else {
           std::cout << "Must specify at least one of {--warble, --read, "
-                       "--profile, --follow}.\n";
+                       "--profile, --follow}." << std::endl;
           return 3;
         }
       }

--- a/warble/warble.cc
+++ b/warble/warble.cc
@@ -30,10 +30,13 @@ int main(int argc, char** argv) {
   CLI cli(CreateChannel(address, InsecureChannelCredentials()));
   if (FLAGS_registeruser == "" && FLAGS_user == "") {
     std::cout << "Must specify either --registeruser (to sign up) or --user "
-                 "(to log in)." << std::endl;
+                 "(to log in)."
+              << std::endl;
     return 1;
   } else if (FLAGS_registeruser != "" && FLAGS_user != "") {
-    std::cout << "Cannot both login and register at the same time. Please use one of the flags." << std::endl;
+    std::cout << "Cannot both login and register at the same time. Please use "
+                 "one of the flags."
+              << std::endl;
   } else {
     if (FLAGS_registeruser != "") {
       cli.RegisterUser(FLAGS_registeruser);
@@ -56,7 +59,8 @@ int main(int argc, char** argv) {
           cli.Follow(FLAGS_user, FLAGS_follow);
         } else {
           std::cout << "Must specify at least one of {--warble, --read, "
-                       "--profile, --follow}." << std::endl;
+                       "--profile, --follow}."
+                    << std::endl;
           return 3;
         }
       }

--- a/warble/warble.cc
+++ b/warble/warble.cc
@@ -24,7 +24,7 @@ DEFINE_bool(profile, false,
 
 int main(int argc, char** argv) {
   google::InitGoogleLogging(argv[0]);
-  gflags::SetUsageMessage("Please run  <warble -h>  to see usage");
+  gflags::SetUsageMessage("Please run with -h flag to see usage");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   std::string address("0.0.0.0:50000");
   CLI cli(CreateChannel(address, InsecureChannelCredentials()));


### PR DESCRIPTION
Added basic persistence for the kvstore server, which dumps the contents upon receiving SIGINT or SIGTERM and reads contents from the file if given the --file flag.

I will probably need to find a better way to serialize the map since I'm currently using newlines as delimiters, which may run into issues.

I think the warble code is already ephemeral. Please see warble/functions.h and func/server.cc (event function) to verify.